### PR TITLE
Add device_info module for SCM device monitoring

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,7 +1,7 @@
 # PRD: Ansible Collection - cdot65.scm (Strata Cloud Manager Integration)
 
 **Version:** 1.1
-**Date:** 2025.04.16
+**Date:** 2025.05.10
 **Author:** Calvin Remsburg
 **Status:** In Development
 
@@ -77,10 +77,10 @@ Users are expected to be familiar with Ansible concepts (playbooks, modules, rol
 The initial release focuses on core SCM objects and actions, with a strong emphasis on robust, reusable Ansible module patterns for each resource type. All new resource modules will follow the folder/folder_info design as the canonical template for structure, authentication, and serialization.
 
 *   **Resource Modules (`_info` and main stateful modules):**
-    *   Folders (`folder`, `folder_info`) — Complete
-    *   Labels (`label`, `label_info`) — Complete
-    *   Snippets (`snippet`, `snippet_info`) — Complete
-    *   Devices (`device`, `device_info`) — Next up, will follow folder module template
+    *   Folders (`folder`, `folder_info`) — Complete ✅
+    *   Labels (`label`, `label_info`) — Complete ✅
+    *   Snippets (`snippet`, `snippet_info`) — Complete ✅
+    *   Devices (`device_info`) — Complete ✅ (read-only operations due to SCM API limitations)
     *   Variables (`variable`, `variable_info`) — Next up, will follow folder module template
     *   Configuration Scopes (`config_scope`, `config_scope_info`)
     *   Address Objects (`address_object`, `address_object_info`)
@@ -279,22 +279,25 @@ The initial release focuses on core SCM objects and actions, with a strong empha
 **Completed:**
 - Folder management modules (`folder`, `folder_info`) fully implemented with modern authentication (bearer token), robust serialization (Pydantic `.model_dump_json()`), and idempotent CRUD/query workflows. These serve as the reference for all future resource modules.
 - Label management modules (`label`, `label_info`) fully implemented.
+- Snippet management modules (`snippet`, `snippet_info`) fully implemented.
+- Device information module (`device_info`) implemented for read-only operations.
 - Authentication role and workflow complete; token can be passed to all modules.
-- Example playbooks for folder and folder_info modules.
+- Example playbooks for all implemented modules.
 
 **In Progress / Next:**
-- Begin work on `snippet`, `device`, and `variable` modules using the folder module template for structure and best practices.
+- Begin work on `variable` modules using the folder module template for structure and best practices.
 - Expand test coverage and documentation for new modules.
 
 **Blocked/Issues:**
 - None major; dependency and serialization issues resolved.
+- Device management limited to read-only operations due to SCM API constraints.
 
 ## 10. Next Steps & Immediate Tasks
 
-- Implement `snippet`, `device`, and `variable` modules using the folder/folder_info pattern.
-- Create corresponding `_info` modules for each.
+- Implement `variable` and `variable_info` modules using the folder/folder_info pattern.
 - Continue to build out example playbooks and integration tests.
 - Ensure all modules are documented and follow the unified authentication/serialization approach.
+- Conduct thorough testing of implemented modules against real SCM instances.
 
 ## 11. Future Considerations
 
@@ -314,5 +317,7 @@ The initial release focuses on core SCM objects and actions, with a strong empha
 
 ## 13. Recent Progress
 
-- The authentication role (`roles/auth`) has been successfully implemented, enabling secure authentication with Strata Cloud Manager. An example playbook demonstrating its use is provided at `playbooks/auth.yml`.
-- Added support for `label` and `label_info` modules (CRUD/query for SCM labels)
+- The authentication role (`roles/auth`) has been successfully implemented, enabling secure authentication with Strata Cloud Manager. Example playbooks demonstrating its use are provided.
+- Added support for `label` and `label_info` modules (CRUD/query for SCM labels).
+- Added support for `snippet` and `snippet_info` modules (CRUD/query for SCM snippets).
+- Implemented `device_info` module for retrieving and filtering device information from SCM.

--- a/README.md
+++ b/README.md
@@ -51,17 +51,18 @@ This collection includes the following modules:
 - `folder`, `folder_info`: Manage and retrieve folders
 - `label`, `label_info`: Manage and retrieve labels
 - `snippet`, `snippet_info`: Manage and retrieve snippets
-- `config_scope`, `config_scope_info`: Manage and retrieve configuration scopes
-- `device`, `device_info`: Manage and retrieve devices
-- `address_object`, `address_object_info`: Manage and retrieve address objects
-- `address_group`, `address_group_info`: Manage and retrieve address groups
-- `service_object`, `service_object_info`: Manage and retrieve service objects
-- `service_group`, `service_group_info`: Manage and retrieve service groups
+- `device_info`: Retrieve device information
+- `config_scope`, `config_scope_info`: Manage and retrieve configuration scopes (planned)
+- `variable`, `variable_info`: Manage and retrieve variables (planned)
+- `address_object`, `address_object_info`: Manage and retrieve address objects (planned)
+- `address_group`, `address_group_info`: Manage and retrieve address groups (planned)
+- `service_object`, `service_object_info`: Manage and retrieve service objects (planned)
+- `service_group`, `service_group_info`: Manage and retrieve service groups (planned)
 
 ### Action Modules
 
-- `deployment`: Trigger configuration push/deployment
-- `job_info`: Check job status
+- `deployment`: Trigger configuration push/deployment (planned)
+- `job_info`: Check job status (planned)
 
 ## Examples
 
@@ -85,6 +86,21 @@ This collection includes the following modules:
 - name: Display folders
   debug:
     var: folders_result.resources
+```
+
+### Retrieving device information
+
+```yaml
+- name: Get all devices
+  cdot65.scm.device_info:
+    scm_access_token: "{{ scm_access_token }}"
+  register: all_devices
+
+- name: Get VM-series firewalls
+  cdot65.scm.device_info:
+    model: "PA-VM"
+    scm_access_token: "{{ scm_access_token }}"
+  register: vm_devices
 ```
 
 ## Development

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO: cdot65.scm Ansible Collection (Strata Cloud Manager)
 
-_Last updated: 2025-05-09_
+_Last updated: 2025-05-10_
 
 ## Immediate Tasks
 
@@ -17,9 +17,8 @@ _Last updated: 2025-05-09_
 - [x] Implement snippet management modules (template: folder modules):
     - [x] `plugins/modules/snippet.py`
     - [x] `plugins/modules/snippet_info.py`
-- [ ] Implement device management modules (template: folder modules):
-    - [ ] `plugins/modules/device.py`
-    - [ ] `plugins/modules/device_info.py`
+- [x] Implement device management modules:
+    - [x] `plugins/modules/device_info.py` (read-only operations for SCM devices)
 - [ ] Implement variable management modules (template: folder modules):
     - [ ] `plugins/modules/variable.py`
     - [ ] `plugins/modules/variable_info.py`

--- a/examples/device_info.yml
+++ b/examples/device_info.yml
@@ -1,0 +1,50 @@
+---
+- name: Authenticate with SCM using the auth role
+  hosts: localhost
+  gather_facts: no
+  roles:
+    - cdot65.scm.auth
+  vars_files:
+    - ../vault.yml
+
+- name: Perform SCM device operations using the established session
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Display authentication info
+      debug:
+        msg: "Authenticated with token: {{ scm_access_token | default('No token available!', true) | truncate(15, true, '...') }}"
+
+    - name: Get device information
+      cdot65.scm.device_info:
+        scm_access_token: "{{ scm_access_token }}"
+      register: all_devices
+
+    - name: Display all devices
+      debug:
+        msg: "Found {{ all_devices.devices | default([]) | length }} devices"
+      when: all_devices.devices is defined
+
+    - name: Get a specific device by name
+      cdot65.scm.device_info:
+        name: "007954000527505"
+        scm_access_token: "{{ scm_access_token }}"
+      register: specific_device
+      ignore_errors: yes
+
+    - name: Display specific device info
+      debug:
+        var: specific_device.devices
+      when: specific_device.devices is defined
+
+    - name: Get all VM-series firewalls
+      cdot65.scm.device_info:
+        model: "PA-VM"
+        scm_access_token: "{{ scm_access_token }}"
+      register: vm_firewalls
+      ignore_errors: yes
+
+    - name: Display VM-series firewalls
+      debug:
+        msg: "Found {{ vm_firewalls.devices | default([]) | length }} VM-series firewalls"
+      when: vm_firewalls.devices is defined

--- a/plugins/modules/device_info.py
+++ b/plugins/modules/device_info.py
@@ -1,0 +1,279 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Calvin Remsburg <cremsburg@paloaltonetworks.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+import json
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: device_info
+short_description: Get information about devices in Strata Cloud Manager (SCM)
+description:
+    - This module retrieves information about devices in Strata Cloud Manager.
+    - It can be used to get details about a specific device by ID or name, or to list all devices.
+    - Supports filtering by device properties like type, model, and folder.
+version_added: "0.1.0"
+author:
+    - "Calvin Remsburg (@cdot65)"
+options:
+    id:
+        description:
+            - The ID of the device to retrieve (typically the serial number).
+            - If specified, the module will return information about this specific device.
+            - Mutually exclusive with I(name).
+        type: str
+        required: false
+    name:
+        description:
+            - The name of the device to retrieve.
+            - If specified, the module will search for devices with this name.
+            - Mutually exclusive with I(id).
+        type: str
+        required: false
+    serial_number:
+        description:
+            - Device serial number.
+            - This is typically the same as the ID, but provided as a separate field for clarity.
+        type: str
+        required: false
+    model:
+        description:
+            - Filter devices by model (e.g., 'PA-VM').
+        type: str
+        required: false
+    type:
+        description:
+            - Filter devices by type (e.g., 'vm', 'firewall', 'panorama').
+        type: str
+        required: false
+    folder:
+        description:
+            - Filter devices by folder name.
+        type: str
+        required: false
+    device_only:
+        description:
+            - If true, only show device-only entries.
+        type: bool
+        required: false
+    scm_access_token:
+        description:
+            - The access token for SCM authentication.
+        type: str
+        required: true
+        no_log: true
+    api_url:
+        description:
+            - The URL for the SCM API.
+        type: str
+        required: false
+notes:
+    - Check mode is supported but does not change behavior since this is a read-only module.
+    - This module uses the pan-scm-sdk for interacting with the SCM API.
+    - Pagination is handled internally when retrieving large device lists.
+'''
+
+EXAMPLES = r'''
+- name: Get all devices
+  cdot65.scm.device_info:
+    scm_access_token: "{{ scm_access_token }}"
+  register: all_devices
+
+- name: Get a specific device by ID (serial number)
+  cdot65.scm.device_info:
+    id: "0123456789"
+    scm_access_token: "{{ scm_access_token }}"
+  register: device_details
+
+- name: Get a specific device by name
+  cdot65.scm.device_info:
+    name: "DC-FW01"
+    scm_access_token: "{{ scm_access_token }}"
+  register: named_device
+
+- name: Get all VM-series firewalls
+  cdot65.scm.device_info:
+    model: "PA-VM"
+    scm_access_token: "{{ scm_access_token }}"
+  register: vm_devices
+
+- name: Get devices in a specific folder
+  cdot65.scm.device_info:
+    folder: "Datacenter"
+    scm_access_token: "{{ scm_access_token }}"
+  register: datacenter_devices
+'''
+
+RETURN = r'''
+devices:
+    description: List of device resources
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        id:
+            description: The device ID (typically serial number)
+            type: str
+            returned: always
+            sample: "0123456789"
+        name:
+            description: The device name
+            type: str
+            returned: always
+            sample: "DC-FW01"
+        serial_number:
+            description: The device serial number
+            type: str
+            returned: always
+            sample: "0123456789"
+        model:
+            description: The device model
+            type: str
+            returned: when applicable
+            sample: "PA-VM"
+        type:
+            description: The device type
+            type: str
+            returned: when applicable
+            sample: "vm"
+        folder:
+            description: The folder containing the device
+            type: str
+            returned: when applicable
+            sample: "Datacenter"
+        description:
+            description: The device description
+            type: str
+            returned: when applicable
+            sample: "Datacenter firewall"
+        display_name:
+            description: The device display name
+            type: str
+            returned: when applicable
+            sample: "Datacenter Firewall"
+        hostname:
+            description: The device hostname
+            type: str
+            returned: when applicable
+            sample: "fw01.example.com"
+        is_connected:
+            description: Connection status
+            type: bool
+            returned: when applicable
+            sample: true
+        connected_since:
+            description: Timestamp when device connected
+            type: str
+            returned: when applicable
+            sample: "2024-05-01T12:00:00.000Z"
+        software_version:
+            description: PAN-OS software version
+            type: str
+            returned: when applicable
+            sample: "10.2.3"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from scm.client import ScmClient
+from scm.exceptions import ObjectNotPresentError, InvalidObjectError, APIError
+
+def main():
+    # Define the module argument specification
+    module_args = dict(
+        name=dict(type='str', required=False),
+        id=dict(type='str', required=False),
+        serial_number=dict(type='str', required=False),
+        model=dict(type='str', required=False),
+        type=dict(type='str', required=False),
+        folder=dict(type='str', required=False),
+        device_only=dict(type='bool', required=False),
+        scm_access_token=dict(type='str', required=True, no_log=True),
+        api_url=dict(type='str', required=False),
+    )
+
+    # Create the module
+    module = AnsibleModule(
+        argument_spec=module_args,
+        mutually_exclusive=[['id', 'name']],
+        supports_check_mode=True
+    )
+
+    # Get parameters
+    params = module.params
+    device_id = params.get('id')
+    name = params.get('name')
+    serial_number = params.get('serial_number')
+    model = params.get('model')
+    device_type = params.get('type')
+    folder = params.get('folder')
+    device_only = params.get('device_only')
+
+    result = {'devices': []}
+
+    try:
+        # Initialize SCM client
+        client = ScmClient(
+            access_token=params['scm_access_token'],
+            api_base_url=params.get('api_url') or "https://api.strata.paloaltonetworks.com",
+        )
+        devices_service = client.device
+
+        # Get device by ID if specified
+        if device_id:
+            try:
+                device = devices_service.get(device_id)
+                if device:
+                    result['devices'] = [json.loads(device.model_dump_json(exclude_unset=True))]
+            except ObjectNotPresentError:
+                # Return empty list if device not found
+                result['devices'] = []
+        
+        # Get device by serial number if specified
+        elif serial_number:
+            try:
+                # Try direct lookup since serial number is often the ID
+                device = devices_service.get(serial_number)
+                if device:
+                    result['devices'] = [json.loads(device.model_dump_json(exclude_unset=True))]
+            except ObjectNotPresentError:
+                # If not found by direct ID lookup, try filtering the list
+                devices = devices_service.list(serial_number=serial_number)
+                device_dicts = [json.loads(d.model_dump_json(exclude_unset=True)) for d in devices]
+                result['devices'] = device_dicts
+        
+        else:
+            # Prepare filter parameters for the SDK
+            filter_params = {}
+            if model:
+                filter_params['model'] = model
+            if device_type:
+                filter_params['type'] = device_type
+            if device_only is not None:
+                filter_params['device_only'] = device_only
+            
+            # List devices with filters
+            devices = devices_service.list(**filter_params)
+            device_dicts = [json.loads(d.model_dump_json(exclude_unset=True)) for d in devices]
+            
+            # Apply additional filtering that may not be supported server-side
+            if name:
+                device_dicts = [d for d in device_dicts if d.get('name') == name]
+            if folder:
+                device_dicts = [d for d in device_dicts if d.get('folder') == folder]
+            
+            result['devices'] = device_dicts
+
+        module.exit_json(**result)
+    except (InvalidObjectError, APIError) as e:
+        module.fail_json(msg=f"API error: {e}", error_code=getattr(e, 'error_code', None), details=getattr(e, 'details', None))
+    except Exception as e:
+        module.fail_json(msg=f"Failed to retrieve device info: {e}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### **User description**
## Summary
- Added device_info module for retrieving device information from SCM
- Created example playbook to demonstrate device_info usage
- Updated documentation to reflect new module capabilities
- Removed placeholder for device.py since SCM API supports read-only operations for devices

## Test plan
- Run the example playbook to verify device information retrieval
- Test different filtering options (model, serial number, type)
- Verify error handling for non-existent devices


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented `device_info` module for SCM device monitoring.

- Added filtering options for device retrieval.

- Updated documentation and examples for `device_info` module.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device_info.py</strong><dd><code>Implement `device_info` module for SCM devices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

plugins/modules/device_info.py

<li>Implemented the <code>device_info</code> module to retrieve device information from <br>SCM.<br> <li> Added options to filter devices by <code>id</code>, <code>name</code>, <code>serial_number</code>, <code>model</code>, <br><code>type</code>, and <code>folder</code>.<br> <li> Integrated with the <code>pan-scm-sdk</code> for interacting with the SCM API.<br> <li> Includes error handling for API requests and device retrieval.


</details>


  </td>
  <td><a href="https://github.com/cdot65/cdot65.scm/pull/7/files#diff-6416511855ae072976138d927cbf0c1c4ff45b9e9ac9b4c6bb9e6daeb8984704">+279/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PRD.md</strong><dd><code>Update PRD with `device_info` module completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

PRD.md

<li>Updated the PRD to reflect the completion of the <code>device_info</code> module.<br> <li> Marked the <code>snippet</code> modules as complete.<br> <li> Updated the "Completed" section to include the <code>device_info</code> module.


</details>


  </td>
  <td><a href="https://github.com/cdot65/cdot65.scm/pull/7/files#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1">+16/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document `device_info` module in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added documentation for the <code>device_info</code> module.<br> <li> Updated the list of modules to include <code>device_info</code>.<br> <li> Added examples for retrieving device information.


</details>


  </td>
  <td><a href="https://github.com/cdot65/cdot65.scm/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+25/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TODO.md</strong><dd><code>Mark `device_info` module as complete in TODO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

TODO.md

- Marked the `device_info` module as complete.


</details>


  </td>
  <td><a href="https://github.com/cdot65/cdot65.scm/pull/7/files#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>device_info.yml</strong><dd><code>Create example playbook for `device_info` module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/device_info.yml

<li>Created an example playbook for using the <code>device_info</code> module.<br> <li> Demonstrates retrieving all devices, a specific device by name, and <br>VM-series firewalls.<br> <li> Includes authentication using the <code>cdot65.scm.auth</code> role.


</details>


  </td>
  <td><a href="https://github.com/cdot65/cdot65.scm/pull/7/files#diff-95d99607cd9d29dc3b109d45bd9a43988d229451dc4c3da09f1a9e3183f2c8b7">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>